### PR TITLE
Added a missing slash to one of the dockerfile COPY instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM frolvlad/alpine-miniconda3 as build
 
 WORKDIR pacpac
-COPY environment.yml setup.py .
+COPY environment.yml setup.py ./
 WORKDIR pacpac
 COPY pacpac .
 WORKDIR ..


### PR DESCRIPTION
Tried building the image which failed at the first COPY instruction - there is a missing slash in the target argument. Since this has nothing to do with the python package, left the version in tact - up to you to decide how to go about it